### PR TITLE
Remove extra space right of viewport from breadcrumbs

### DIFF
--- a/themes/phills/layouts/partials/breadcrumbs.html
+++ b/themes/phills/layouts/partials/breadcrumbs.html
@@ -1,11 +1,11 @@
 {{- if .Parent }}
 {{- if not .Parent.IsHome }}
-<div class="breadcrumbs pure-u-1">
-    <nav class="content-inner pure-menu pure-menu-horizontal">
+<div class="breadcrumbs pure-u-1"><div class="content-inner">
+    <nav class="pure-menu pure-menu-horizontal">
         <ul class="pure-menu-list">
             {{ partial "breadcrumb/item" .Parent }}
         </ul>
     </nav>
-</div>
+</div></div>
 {{- end }}
 {{- end }}


### PR DESCRIPTION
There was an odd interaction between `.content-inner` and `.pure-menu` that caused a whitespace bleed to the right of the viewport (causing a small amount of horizontal scroll on all pages with breadcrumbs).  Splitting these into their own elements has solved the problem.