### PR TITLE
Update links to The Tower Climbing Centre

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -23,4 +23,4 @@ I enjoy climbing in all forms, especially sport and trad climbing when the weath
 [nicas]: https://www.nicas.co.uk/
 [scout-permits]: /course/scouts-climbing-permits/
 [thescouts]: https://scouts.org.uk/
-[tower]: https://towerclimbingcentre.wordpress.com/
+[tower]: https://leicester.gov.uk/climbing/

--- a/content/experience/climbing/freelance-and-casual.md
+++ b/content/experience/climbing/freelance-and-casual.md
@@ -26,6 +26,6 @@ Leading sessions of bouldering and top-rope climbing with groups of children, yo
 
 Working with groups of any age to deliver challenge experiences including Climbing, Abseiling and High Ropes from no experience to regular centre users.
 
-#### [The Tower Climbing Centre](http://thetowerclimbingcentre.co.uk/) <small>(2013 onwards)</small>
+#### [The Tower Climbing Centre](https://leicester.gov.uk/climbing/) <small>(2013 onwards)</small>
 
 Instructing groups and parties of varying ages and abilities as required, including 4 week introductory courses, 4 week learn to lead climb courses and NICAS levels 1–4. Also responsible for greeting customers, conducting competency tests for new members and maintaining health and safety standards within the facility.

--- a/content/experience/climbing/the-tower-climbing-centre-course-director.md
+++ b/content/experience/climbing/the-tower-climbing-centre-course-director.md
@@ -7,7 +7,7 @@ date = "2018-05-21"
 
 [company]
   name = "The Tower Climbing Centre"
-  url = "https://www.leicester.gov.uk/leisure-and-culture/sport-and-leisure/the-tower-climbing-centre/"
+  url = "https://leicester.gov.uk/climbing/"
 +++
 
 Along with assisting with the general running of the centre, I also oversee NICAS and NIBAS here, including inducting staff, teaching courses and coaching candidates.


### PR DESCRIPTION
The WordPress site has been taken down and replaced with pages on the council's website.